### PR TITLE
Added shade plugin back in.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "eclipse"
     id "idea"
     id "jacoco"
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 //Easy semantic version based off describe + tags


### PR DESCRIPTION
@makosblade This has to be shaded with all compile dependencies since it is deployed into Spark, which is missing a bunch of dependencies like hazelcast.

Wanted to run it by you and make sure you didn't have a different plan for that.
